### PR TITLE
Updating .kitchen.yml to remove dependency on box-cutter images,

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,10 +12,7 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: centos65
-    driver:
-      box: box-cutter/centos65
-      box_url: box-cutter/centos65
+  - name: centos-6.5
     attributes:
       chef_server12:
         topology: 'standalone'
@@ -30,10 +27,8 @@ platforms:
           node1.vagrantup.com: "<%= chef_node1_ip %>"
           node2.vagrantup.com: "<%= chef_node2_ip %>"
 
-  - name: ubuntu1404
+  - name: ubuntu-14.04
     driver:
-      box: box-cutter/ubuntu1404
-      box_url: box-cutter/ubuntu1404
     attributes:
       chef_server12:
         topology: 'standalone'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -42,3 +42,5 @@ default['chef_server12']['organization_private_key'] = \
    "#{node['chef_server12']['organization']}-validator.pem"
 default['chef_server12']['organization_private_key_path'] = \
    File.join('/tmp', node['chef_server12']['organization_private_key'])
+# Option to bootstrap test nodes
+default['chef_server12']['create_nodes'] = false

--- a/recipes/standalone.rb
+++ b/recipes/standalone.rb
@@ -6,4 +6,5 @@ include_recipe 'chef-server12::_create_org'
 include_recipe 'chef-server12::_create_ssh_key_for_server'
 include_recipe 'chef-server12::_configure_analytics' \
   if node['chef_server12']['analytics']
-include_recipe 'chef-server12::_add_nodes'
+include_recipe 'chef-server12::_add_nodes' \
+  if node['chef_server12']['create_nodes']


### PR DESCRIPTION
using Opscode bento instead. Added boolean attribute to make use of
test nodes optional in the standalone recipe.
