### PR TITLE
Fixing attributes in analytics.rb due to naming convention refering to '...

### DIFF
--- a/recipes/analytics.rb
+++ b/recipes/analytics.rb
@@ -1,6 +1,6 @@
-include_recipe 'chef-server12::_add_server_to_authorized_keys'
-include_recipe 'chef-server12::_configure_analytics_dns' \
-  if node['chef-server12']['write_hosts']
+include_recipe 'chef_server12::_add_server_to_authorized_keys'
+include_recipe 'chef_server12::_configure_analytics_dns' \
+  if node['chef_server12']['write_hosts']
 
 analytics_fqdn = node['chef_server12']['backend']['analytics_fqdn']
 


### PR DESCRIPTION
...chef-server'

rather than 'chef_server'
